### PR TITLE
Update AzDO ACA deploy templates

### DIFF
--- a/.azdo/pipelines/2-build-deploy-app-pipeline.yml
+++ b/.azdo/pipelines/2-build-deploy-app-pipeline.yml
@@ -9,6 +9,15 @@ trigger: none
 
 # ----------------------------------------------------------------------------------------------------
 parameters:
+- name: deployToEnvironment
+  displayName: Deploy To
+  type: string
+  values:
+    - DEV
+    - QA
+    - PROD
+    - DEV-QA-PROD
+  default: DEV
 - name: buildApps
   displayName: Build Docker Images
   type: boolean
@@ -51,11 +60,25 @@ stages:
             runMSDevSecOpsScan: ${{ parameters.runMSDevSecOpsScan }}
             runGHASScan: false
 
-- template: pipes/build-deploy-app-pipe.yml
-  parameters:
-    pushToACR: ${{ parameters.pushApps }}
-    deployAction: ${{ parameters.deployAction }}
-    updateACRFirewall: ${{ parameters.updateACRFirewall }}
-    apps: [ 
-      { containerAppName: 'ui',  acrAppName: 'chatui',  projectFolderName: 'src/website/chatui', port: '8080' }
-    ] 
+- ${{ if ne(parameters.deployToEnvironment, 'DEV-QA-PROD') }}:
+  - template: pipes/build-deploy-app-pipe.yml
+    parameters:
+      environments: ['${{ parameters.deployToEnvironment }}']
+      singleEnvironment: 'true'
+      pushToACR: ${{ parameters.pushApps }}
+      deployAction: ${{ parameters.deployAction }}
+      updateACRFirewall: ${{ parameters.updateACRFirewall }}
+      apps: [ 
+        { containerAppName: 'ui',  acrAppName: 'chatui',  projectFolderName: 'src/website/chatui', port: '8080' }
+      ] 
+
+- ${{ if eq(parameters.deployToEnvironment, 'DEV-QA-PROD') }}:
+  - template: pipes/build-deploy-app-pipe.yml
+    parameters:
+      environments: ['DEV', 'QA', 'PROD']
+      pushToACR: ${{ parameters.pushApps }}
+      deployAction: ${{ parameters.deployAction }}
+      updateACRFirewall: ${{ parameters.updateACRFirewall }}
+      apps: [ 
+        { containerAppName: 'ui',  acrAppName: 'chatui',  projectFolderName: 'src/website/chatui', port: '8080' }
+      ] 

--- a/.azdo/pipelines/pipes/build-deploy-app-pipe.yml
+++ b/.azdo/pipelines/pipes/build-deploy-app-pipe.yml
@@ -5,6 +5,8 @@ parameters:
   - name: environments
     type: object
     default: ['DEV']
+  - name: singleEnvironment
+    default: 'false'
   - name: apps
     type: object
     default: []
@@ -20,8 +22,9 @@ parameters:
 stages:
 - ${{ each environmentCode in parameters.environments }}:
   - ${{ each app in parameters.apps }}:
-    - stage: Build${{ app.containerAppName }}${{ environmentCode }}App
+    - stage: Build${{ app.containerAppName }}${{ environmentCode }}
       displayName: Build ${{ app.containerAppName }} ${{ environmentCode }}
+      condition: or(eq(${{ parameters.singleEnvironment }}, 'true'), eq(upper('${{ environmentCode }}'), 'DEV'), and(eq(upper('${{ environmentCode }}'), 'QA'), succeeded('Deploy${{ app.containerAppName }}Dev')), and(eq(upper('${{ environmentCode }}'), 'PROD'), succeeded('Deploy${{ app.containerAppName }}QA')))
       jobs:
         - template: templates/aca-build-template.yml
           parameters:
@@ -32,9 +35,10 @@ stages:
             pushToACR: ${{ parameters.pushToACR }}
             updateFirewall: ${{ parameters.updateACRFirewall }}
 
-    - stage: Deploy${{ app.containerAppName }}${{ environmentCode }}App
+    - stage: Deploy${{ app.containerAppName }}${{ environmentCode }}
       displayName: Deploy ${{ app.containerAppName }} ${{ environmentCode }}
       condition: and(succeeded(), eq(lower('${{ parameters.deployAction }}'), 'build-deploy'))
+      dependsOn: Build${{ app.containerAppName }}${{ environmentCode }}
       jobs:
         - template: templates/aca-deploy-template.yml
           parameters:
@@ -44,9 +48,10 @@ stages:
             acrAppName: ${{ app.acrAppName }}
             port: ${{ app.port }}
   
-    - stage: Create${{ app.containerAppName }}${{ environmentCode }}App
+    - stage: Create${{ app.containerAppName }}${{ environmentCode }}
       displayName: Create ${{ app.containerAppName }} ${{ environmentCode }}
       condition: and(succeeded(), eq(lower('${{ parameters.deployAction }}'), 'create-build-deploy'))
+      dependsOn: Build${{ app.containerAppName }}${{ environmentCode }}
       jobs:
         - template: templates/aca-create-template.yml
           parameters:

--- a/.azdo/pipelines/pipes/infra-only-pipe.yml
+++ b/.azdo/pipelines/pipes/infra-only-pipe.yml
@@ -5,14 +5,14 @@ parameters:
   - name: environments
     type: object
     default: ['DEV']
+  - name: singleEnvironment
+    default: 'false'
   - name: templateFolderName
     default: 'infra/bicep'
   - name: bicepVersion
     default: 'basic'
   - name: deploymentMode
     default: 'Incremental'
-  - name: singleEnvironment
-    default: 'false'
   - name: appsToDeploy
     default: 'none'
   - name: createResourceGroup

--- a/.azdo/pipelines/pipes/templates/aca-create-template.yml
+++ b/.azdo/pipelines/pipes/templates/aca-create-template.yml
@@ -67,9 +67,9 @@ jobs:
             echo "##vso[task.setvariable variable=imageName]$imageName"
             $acrName='cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER)'
             echo "##vso[task.setvariable variable=acrName]$acrName"
-
             $containerRegistryUrl="cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER).azurecr.io"
             echo "##vso[task.setvariable variable=containerRegistryUrl]$containerRegistryUrl"
+
             $userAssignedIdentityId="id-$($appNameNoDashesLower)-$($environmentCodeLower)-$(INSTANCE_NUMBER)"
             echo "##vso[task.setvariable variable=userAssignedIdentityId]$userAssignedIdentityId"
             $containerAppEnvName="cae-$($appNameNoDashesLower)-$($environmentCodeLower)-$(INSTANCE_NUMBER)"

--- a/.azdo/pipelines/pipes/templates/aca-create-template.yml
+++ b/.azdo/pipelines/pipes/templates/aca-create-template.yml
@@ -68,7 +68,7 @@ jobs:
             $acrName='cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER)'
             echo "##vso[task.setvariable variable=acrName]$acrName"
 
-            $containerRegistryUrl="$acrName.azurecr.io"
+            $containerRegistryUrl="cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER).azurecr.io"
             echo "##vso[task.setvariable variable=containerRegistryUrl]$containerRegistryUrl"
             $userAssignedIdentityId="id-$($appNameNoDashesLower)-$($environmentCodeLower)-$(INSTANCE_NUMBER)"
             echo "##vso[task.setvariable variable=userAssignedIdentityId]$userAssignedIdentityId"

--- a/.azdo/pipelines/pipes/templates/aca-deploy-template.yml
+++ b/.azdo/pipelines/pipes/templates/aca-deploy-template.yml
@@ -65,7 +65,7 @@ jobs:
             echo "##vso[task.setvariable variable=caAppName]$caAppName"
             $imageName="$($acrFolderNameLower)/$($acrAppNameLower):$(Build.BuildId)"
             echo "##vso[task.setvariable variable=imageName]$imageName"
-            $acrName='cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER)'
+            $acrName="cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER)"
             echo "##vso[task.setvariable variable=acrName]$acrName"
 
             echo "environmentCodeLower=$environmentCodeLower"

--- a/.azdo/pipelines/pipes/templates/aca-deploy-template.yml
+++ b/.azdo/pipelines/pipes/templates/aca-deploy-template.yml
@@ -67,6 +67,8 @@ jobs:
             echo "##vso[task.setvariable variable=imageName]$imageName"
             $acrName="cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER)"
             echo "##vso[task.setvariable variable=acrName]$acrName"
+            $containerRegistryUrl="cr$($appNameNoDashesLower)$($environmentCodeLower)$(INSTANCE_NUMBER).azurecr.io"
+            echo "##vso[task.setvariable variable=containerRegistryUrl]$containerRegistryUrl"
 
             echo "environmentCodeLower=$environmentCodeLower"
             echo "appNameNoDashesLower=$appNameNoDashesLower"
@@ -83,6 +85,19 @@ jobs:
             echo "##[group]Display All Environment Variables:"
             printenv | sort
             echo "##[endgroup]"
+
+      # # ----------------------------------------------------------------------------------------------------
+      # # Log into ACR
+      # # ----------------------------------------------------------------------------------------------------
+      # - task: AzureCLI@2
+      #   displayName: 'ACR: Docker Login'
+      #   inputs:
+      #     AzureSubscription: $(serviceConnectionName)
+      #     scriptType: bash
+      #     scriptLocation: inlineScript
+      #     inlineScript: |
+      #       echo "Logging in to $(acrName)"
+      #       az acr login -n $(acrName)
 
       # ----------------------------------------------------------------------------------------------------
       # Deploy the container app image


### PR DESCRIPTION
This pull request updates the Azure DevOps pipeline configuration to improve deployment flexibility and maintain consistency in resource naming. The main changes introduce a new deployment parameter to control target environments, refactor stage naming for clarity, and fix resource URL formatting in deployment templates.

**Pipeline parameterization and deployment logic:**

* Added a new `deployToEnvironment` parameter to `.azdo/pipelines/2-build-deploy-app-pipeline.yml`, allowing selection of specific environments (DEV, QA, PROD, or all) for deployment.
* Updated pipeline logic to handle single or multiple environment deployments based on the `deployToEnvironment` parameter, including conditional template invocation for environment-specific deployments.

**Stage and template refactoring:**

* Refactored stage names in `.azdo/pipelines/pipes/build-deploy-app-pipe.yml` by removing the redundant `App` suffix, and added stage dependencies to ensure correct build-deploy-create sequencing. Also introduced the `singleEnvironment` parameter for more granular control. [[1]](diffhunk://#diff-ef63ea2957f3789d3ef11157d4eee3d123abb745af468ac28fc331f15b1e4bb5L23-R27) [[2]](diffhunk://#diff-ef63ea2957f3789d3ef11157d4eee3d123abb745af468ac28fc331f15b1e4bb5L35-R41) [[3]](diffhunk://#diff-ef63ea2957f3789d3ef11157d4eee3d123abb745af468ac28fc331f15b1e4bb5L47-R54) [[4]](diffhunk://#diff-ef63ea2957f3789d3ef11157d4eee3d123abb745af468ac28fc331f15b1e4bb5R8-R9)

**Resource naming consistency:**

* Fixed the construction of the Azure Container Registry URL in `.azdo/pipelines/pipes/templates/aca-create-template.yml` to use the correct format.
* Standardized the assignment of the `acrName` variable in `.azdo/pipelines/pipes/templates/aca-deploy-template.yml` for consistency.

**Parameter cleanup:**

* Removed duplicate and misplaced `singleEnvironment` parameter definition from `.azdo/pipelines/pipes/infra-only-pipe.yml`.